### PR TITLE
Provide meaningful messages on empty INI files

### DIFF
--- a/src/sim.nim
+++ b/src/sim.nim
@@ -74,7 +74,7 @@ proc getValue[T](cfg: Config, value: var T, section, key: string) =
       if not cfg.hasKey(key):
         raise newException(SectionNotFoundException, &"Section `{key}` not found")
     else:
-      if not cfg[""].hasKey(key):
+      if "" notin cfg or key notin cfg[""]:
         raise newException(KeyNotFoundException, &"Key `{key}` not found in top level section")
   else:
     if T is object:
@@ -82,7 +82,7 @@ proc getValue[T](cfg: Config, value: var T, section, key: string) =
       if not cfg.hasKey(key):
         raise newException(SectionNotFoundException, &"Section `{key}` not found")
     else:
-      if not cfg[section].hasKey(key):
+      if section notin cfg or key notin cfg[section]:
         raise newException(KeyNotFoundException, &"Key `{key}` not found in section `{section}`")
 
   var v {.used.} = cfg.getSectionValue(section, key)
@@ -110,7 +110,7 @@ proc getValue[T](cfg: Config, value: var T, section, key: string) =
   elif T is object:
     var key = key
     if section.len != 0:
-      key =  &"{section}/{key}"
+      key = &"{section}/{key}"
     for k, v in value.fieldPairs():
       cfg.getValue(v, key, !k)
   else:

--- a/tests/config8.ini
+++ b/tests/config8.ini
@@ -1,0 +1,1 @@
+; This is an empty INI file with no entries

--- a/tests/test8.nim
+++ b/tests/test8.nim
@@ -1,0 +1,12 @@
+import unittest, sim
+
+type
+  Config = object
+    data: string
+
+suite "parse ini":
+  test "empty ini file still works and gives meningful exception":
+    try:
+      var cfg = to[Config]("tests/config8.ini")
+    except KeyNotFoundException as e:
+      assert e.msg == "Key `data` not found in top level section"


### PR DESCRIPTION
Empty INI files weren't taken into account in tests, so if it's empy, then the provided error message provides no clue of what's going on:

> Error: unhandled exception: key not found:  [KeyError]

The patch provides a check for cfg[""], so it doesn't fail and provides an useful message:

> Key `data` not found in top level section 

I added tests (test8) to check this issue. Let me know if you need anything else related to this.