### PR TITLE
ci: disable macos while it's not working on iffy\install-nim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os:
           - windows-latest
-          - macos-latest
+          # - macos-latest
           - ubuntu-latest
         nimversion:
           - stable


### PR DESCRIPTION
Lately, MacOS builds are failing. It's a good idea to disable them while it's fixed upstream on iffy\install-nim